### PR TITLE
[cudapoa] fix for Error code 8

### DIFF
--- a/cudapoa/src/cudapoa_nw_banded.cu
+++ b/cudapoa/src/cudapoa_nw_banded.cu
@@ -54,7 +54,7 @@ __device__ ScoreT* get_score_ptr(ScoreT* scores, SizeT row, SizeT column, float 
 
     if (column == 0)
     {
-        col_idx = band_start;
+        col_idx = 0;
     }
     else
     {


### PR DESCRIPTION
Fixed a bug in banded NW where in some cases would throw `loop_count_exceeded_upper_bound` error code and failed to complete the alignment.
It would happen for cases where trace-back path would hit left boundary of the band.