### PR TITLE
[cudamapper] Added skip_copy_to_host to IndexCacheHost

### DIFF
--- a/cudamapper/src/index_cache.cuh
+++ b/cudamapper/src/index_cache.cuh
@@ -77,8 +77,10 @@ public:
     ///
     /// \param descriptors_of_indices_to_cache descriptors on indices to keep in host memory
     /// \param descriptors_of_indices_to_keep_on_device descriptors of indices to keep in device memory in addition to host memory until retrieved for the first time
+    /// \param skip_copy_to_host this option should be used if descriptors_of_indices_to_cache == descriptors_of_indices_to_keep_on_device and if each index will be queried only once, it's usefull for small cases where host cache isn't actually needed
     void generate_query_cache_content(const std::vector<IndexDescriptor>& descriptors_of_indices_to_cache,
-                                      const std::vector<IndexDescriptor>& descriptors_of_indices_to_keep_on_device = {});
+                                      const std::vector<IndexDescriptor>& descriptors_of_indices_to_keep_on_device = {},
+                                      bool skip_copy_to_host                                                       = false);
 
     /// \brief Discards previously cached target Indices, creates new Indices and copies them to host memory
     ///
@@ -88,8 +90,10 @@ public:
     ///
     /// \param descriptors_of_indices_to_cache descriptors on indices to keep in host memory
     /// \param descriptors_of_indices_to_keep_on_device descriptors of indices to keep in device memory in addition to host memory until retrieved for the first time
+    /// \param skip_copy_to_host this option should be used if descriptors_of_indices_to_cache == descriptors_of_indices_to_keep_on_device and if each index will be queried only once, it's usefull for small cases where host cache isn't actually needed
     void generate_target_cache_content(const std::vector<IndexDescriptor>& descriptors_of_indices_to_cache,
-                                       const std::vector<IndexDescriptor>& descriptors_of_indices_to_keep_on_device = {});
+                                       const std::vector<IndexDescriptor>& descriptors_of_indices_to_keep_on_device = {},
+                                       bool skip_copy_to_host                                                       = false);
 
     /// \brief Copies request Index to device memory
     /// throws if that index is currently not in cache
@@ -120,6 +124,7 @@ private:
     /// If same_query_and_target_ is true function checks the other cache to see if that index is already in cache
     void generate_cache_content(const std::vector<IndexDescriptor>& descriptors_of_indices_to_cache,
                                 const std::vector<IndexDescriptor>& descriptors_of_indices_to_keep_on_device,
+                                bool skip_copy_to_host,
                                 CacheSelector which_cache);
 
     /// \brief Fetches requested index


### PR DESCRIPTION
For many smaller cases (e.g. bacteria) all indices fit device memory. Currently such indices would still be copied to host. This PR introduces an option to instruct `IndexCacheHost` to skip that copy.

Part of issue #318 