### PR TITLE
[cudapoa] Member type and size unification

### DIFF
--- a/cudapoa/include/claragenomics/cudapoa/batch.hpp
+++ b/cudapoa/include/claragenomics/cudapoa/batch.hpp
@@ -55,7 +55,7 @@ struct BatchSize
     /// Maximum number of elements in a sequence
     int32_t max_sequence_size;
     /// Maximum size of final consensus
-    int32_t max_concensus_size;
+    int32_t max_consensus_size;
     /// Maximum number of nodes in a POA graph, one graph per window
     int32_t max_nodes_per_window;
     /// Maximum number of nodes in a POA graph in banded alignment, one graph per window
@@ -75,7 +75,7 @@ struct BatchSize
     BatchSize(int32_t max_seq_sz = 1024, int32_t max_seq_per_poa = 100, int32_t band_width = 128)
         /// ensure a 4-byte boundary alignment for any allocated buffer
         : max_sequence_size(max_seq_sz)
-        , max_concensus_size(2 * max_sequence_size)
+        , max_consensus_size(2 * max_sequence_size)
         , max_nodes_per_window(cudautils::align<int32_t, 4>(3 * max_sequence_size))
         , max_nodes_per_window_banded(cudautils::align<int32_t, 4>(4 * max_sequence_size))
         , max_matrix_graph_dimension(cudautils::align<int32_t, 4>(max_nodes_per_window))
@@ -96,11 +96,11 @@ struct BatchSize
     }
 
     /// constructor- set all parameters separately
-    BatchSize(int32_t max_seq_sz, int32_t max_concensus_sz, int32_t max_nodes_per_w,
+    BatchSize(int32_t max_seq_sz, int32_t max_consensus_sz, int32_t max_nodes_per_w,
               int32_t max_nodes_per_w_banded, int32_t band_width, int32_t max_seq_per_poa)
         /// ensure a 4-byte boundary alignment for any allocated buffer
         : max_sequence_size(max_seq_sz)
-        , max_concensus_size(max_concensus_sz)
+        , max_consensus_size(max_consensus_sz)
         , max_nodes_per_window(cudautils::align<int32_t, 4>(max_nodes_per_w))
         , max_nodes_per_window_banded(cudautils::align<int32_t, 4>(max_nodes_per_w_banded))
         , max_matrix_graph_dimension(cudautils::align<int32_t, 4>(max_nodes_per_window))
@@ -111,7 +111,7 @@ struct BatchSize
         , max_sequences_per_poa(max_seq_per_poa)
     {
         throw_on_negative(max_seq_sz, "max_sequence_size cannot be negative.");
-        throw_on_negative(max_concensus_sz, "max_concensus_size cannot be negative.");
+        throw_on_negative(max_consensus_sz, "max_consensus_size cannot be negative.");
         throw_on_negative(max_nodes_per_w, "max_nodes_per_window cannot be negative.");
         throw_on_negative(max_nodes_per_w_banded, "max_nodes_per_window_banded cannot be negative.");
         throw_on_negative(max_seq_per_poa, "max_sequences_per_poa cannot be negative.");
@@ -121,8 +121,8 @@ struct BatchSize
             throw std::invalid_argument("max_nodes_per_window should be greater than or equal to max_sequence_size.");
         if (max_nodes_per_window_banded < max_sequence_size)
             throw std::invalid_argument("max_nodes_per_window should be greater than or equal to max_sequence_size.");
-        if (max_concensus_size < max_sequence_size)
-            throw std::invalid_argument("max_concensus_size should be greater than or equal to max_sequence_size.");
+        if (max_consensus_size < max_sequence_size)
+            throw std::invalid_argument("max_consensus_size should be greater than or equal to max_sequence_size.");
         if (max_sequence_size < alignment_band_width)
             throw std::invalid_argument("alignment_band_width should not be greater than max_sequence_size.");
     }

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -78,7 +78,7 @@ public:
         max_poas_                            = avail_mem / (device_size_per_poa + device_size_per_score_matrix);
 
         // Update final sizes for block based on calculated maximum POAs.
-        output_size_ = max_poas_ * static_cast<int64_t>(batch_size.max_concensus_size);
+        output_size_ = max_poas_ * static_cast<int64_t>(batch_size.max_consensus_size);
         input_size_  = max_poas_ * max_sequences_per_poa_ * static_cast<int64_t>(batch_size.max_sequence_size);
         total_h_     = max_poas_ * host_size_per_poa + host_size_fixed;
         total_d_     = avail_mem;
@@ -301,7 +301,7 @@ protected:
         int64_t host_size_per_poa = 0, device_size_per_poa = 0;
 
         int64_t input_size_per_poa  = max_sequences_per_poa_ * batch_size.max_sequence_size * poa_count;
-        int64_t output_size_per_poa = batch_size.max_concensus_size * poa_count;
+        int64_t output_size_per_poa = batch_size.max_consensus_size * poa_count;
 
         // for output - host
         host_size_fixed += sizeof(OutputDetails);                                                                                                                        // output_details_h_

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -222,7 +222,7 @@ public:
 
         // on device
         graph_details_d->nodes = &block_data_d_[offset_d_];
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_h->nodes) * max_nodes_per_window_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->nodes) * max_nodes_per_window_ * max_poas_);
         graph_details_d->node_alignments = reinterpret_cast<decltype(graph_details_d->node_alignments)>(&block_data_d_[offset_d_]);
         offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_alignments) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * max_poas_);
         graph_details_d->node_alignment_count = reinterpret_cast<decltype(graph_details_d->node_alignment_count)>(&block_data_d_[offset_d_]);

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -94,7 +94,7 @@ public:
         CGA_CU_CHECK_ERR(cudaFreeHost(block_data_h_));
     }
 
-        void get_output_details(OutputDetails** output_details_h_p, OutputDetails** output_details_d_p)
+    void get_output_details(OutputDetails** output_details_h_p, OutputDetails** output_details_d_p)
     {
         OutputDetails* output_details_h{};
         OutputDetails* output_details_d{};
@@ -180,7 +180,7 @@ public:
         *input_details_d_p = input_details_d;
     }
 
-        void get_alignment_details(AlignmentDetails<ScoreT, SizeT>** alignment_details_d_p)
+    void get_alignment_details(AlignmentDetails<ScoreT, SizeT>** alignment_details_d_p)
     {
         AlignmentDetails<ScoreT, SizeT>* alignment_details_d{};
 

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -304,68 +304,68 @@ protected:
         int64_t output_size_per_poa = batch_size.max_concensus_size * poa_count;
 
         // for output - host
-        host_size_fixed += sizeof(OutputDetails);                                                                                   // output_details_h_
-        host_size_per_poa += output_size_per_poa * sizeof(uint8_t);                                                                 // output_details_h_->consensus
-        host_size_per_poa += (output_mask_ & OutputType::consensus) ? output_size_per_poa * sizeof(uint16_t) : 0;                   // output_details_h_->coverage
-        host_size_per_poa += (output_mask_ & OutputType::msa) ? output_size_per_poa * max_sequences_per_poa_ * sizeof(uint8_t) : 0; // output_details_h_->multiple_sequence_alignments
-        host_size_per_poa += sizeof(OutputDetails);                                                                                 // output_details_d_
+        host_size_fixed += sizeof(OutputDetails);                                                                                                                        // output_details_h_
+        host_size_per_poa += output_size_per_poa * sizeof(*OutputDetails::consensus);                                                                                    // output_details_h_->consensus
+        host_size_per_poa += (output_mask_ & OutputType::consensus) ? output_size_per_poa * sizeof(*OutputDetails::coverage) : 0;                                        // output_details_h_->coverage
+        host_size_per_poa += (output_mask_ & OutputType::msa) ? output_size_per_poa * max_sequences_per_poa_ * sizeof(*OutputDetails::multiple_sequence_alignments) : 0; // output_details_h_->multiple_sequence_alignments
+        host_size_per_poa += sizeof(OutputDetails);                                                                                                                      // output_details_d_
         // for output - device
-        device_size_per_poa += output_size_per_poa * sizeof(uint8_t);                                                                 // output_details_d_->consensus
-        device_size_per_poa += (output_mask_ & OutputType::consensus) ? output_size_per_poa * sizeof(uint16_t) : 0;                   // output_details_d_->coverage
-        device_size_per_poa += (output_mask_ & OutputType::msa) ? output_size_per_poa * max_sequences_per_poa_ * sizeof(uint8_t) : 0; // output_details_d_->multiple_sequence_alignments
+        device_size_per_poa += output_size_per_poa * sizeof(*OutputDetails::consensus);                                                                                    // output_details_d_->consensus
+        device_size_per_poa += (output_mask_ & OutputType::consensus) ? output_size_per_poa * sizeof(*OutputDetails::coverage) : 0;                                        // output_details_d_->coverage
+        device_size_per_poa += (output_mask_ & OutputType::msa) ? output_size_per_poa * max_sequences_per_poa_ * sizeof(*OutputDetails::multiple_sequence_alignments) : 0; // output_details_d_->multiple_sequence_alignments
 
         // for input - host
-        host_size_fixed += sizeof(InputDetails<SizeT>);                                                                 // input_details_h_
-        host_size_per_poa += input_size_per_poa * sizeof(uint8_t);                                                      // input_details_h_->sequences
-        host_size_per_poa += input_size_per_poa * sizeof(int8_t);                                                       // input_details_h_->base_weights
-        host_size_per_poa += poa_count * max_sequences_per_poa_ * sizeof(SizeT);                                        // input_details_h_->sequence_lengths
-        host_size_per_poa += poa_count * sizeof(WindowDetails);                                                         // input_details_h_->window_details
-        host_size_per_poa += (output_mask_ & OutputType::msa) ? poa_count * max_sequences_per_poa_ * sizeof(SizeT) : 0; // input_details_h_->sequence_begin_nodes_ids
+        host_size_fixed += sizeof(InputDetails<SizeT>);                                                                                                          // input_details_h_
+        host_size_per_poa += input_size_per_poa * sizeof(*InputDetails<SizeT>::sequences);                                                                       // input_details_h_->sequences
+        host_size_per_poa += input_size_per_poa * sizeof(*InputDetails<SizeT>::base_weights);                                                                    // input_details_h_->base_weights
+        host_size_per_poa += poa_count * max_sequences_per_poa_ * sizeof(*InputDetails<SizeT>::sequence_lengths);                                                // input_details_h_->sequence_lengths
+        host_size_per_poa += poa_count * sizeof(*InputDetails<SizeT>::window_details);                                                                           // input_details_h_->window_details
+        host_size_per_poa += (output_mask_ & OutputType::msa) ? poa_count * max_sequences_per_poa_ * sizeof(*InputDetails<SizeT>::sequence_begin_nodes_ids) : 0; // input_details_h_->sequence_begin_nodes_ids
 
-        host_size_fixed += sizeof(InputDetails<SizeT>); // input_details_d_
-        // for input - device
-        device_size_per_poa += input_size_per_poa * sizeof(uint8_t);                                                      // input_details_d_->sequences
-        device_size_per_poa += input_size_per_poa * sizeof(int8_t);                                                       // input_details_d_->base_weights
-        device_size_per_poa += poa_count * max_sequences_per_poa_ * sizeof(SizeT);                                        // input_details_d_->sequence_lengths
-        device_size_per_poa += poa_count * sizeof(WindowDetails);                                                         // input_details_d_->window_details
-        device_size_per_poa += (output_mask_ & OutputType::msa) ? poa_count * max_sequences_per_poa_ * sizeof(SizeT) : 0; // input_details_d_->sequence_begin_nodes_ids
+        host_size_fixed += sizeof(InputDetails<SizeT>);                                                                                                            // input_details_d_
+                                                                                                                                                                   // for input - device
+        device_size_per_poa += input_size_per_poa * sizeof(*InputDetails<SizeT>::sequences);                                                                       // input_details_d_->sequences
+        device_size_per_poa += input_size_per_poa * sizeof(*InputDetails<SizeT>::base_weights);                                                                    // input_details_d_->base_weights
+        device_size_per_poa += poa_count * max_sequences_per_poa_ * sizeof(*InputDetails<SizeT>::sequence_lengths);                                                // input_details_d_->sequence_lengths
+        device_size_per_poa += poa_count * sizeof(*InputDetails<SizeT>::window_details);                                                                           // input_details_d_->window_details
+        device_size_per_poa += (output_mask_ & OutputType::msa) ? poa_count * max_sequences_per_poa_ * sizeof(*InputDetails<SizeT>::sequence_begin_nodes_ids) : 0; // input_details_d_->sequence_begin_nodes_ids
 
         // for graph - host
-        host_size_fixed += sizeof(GraphDetails<SizeT>);                                                     // graph_details_h_
-        host_size_fixed += sizeof(GraphDetails<SizeT>);                                                     // graph_details_d_
-        host_size_per_poa += sizeof(uint8_t) * max_nodes_per_window_ * poa_count;                           // graph_details_h_->nodes
-        host_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;    // graph_details_d_->incoming_edges
-        host_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count; // graph_details_d_->incoming_edge_weights
-        host_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                          // graph_details_d_->incoming_edge_count
+        host_size_fixed += sizeof(GraphDetails<SizeT>);                                                                                        // graph_details_h_
+        host_size_fixed += sizeof(GraphDetails<SizeT>);                                                                                        // graph_details_d_
+        host_size_per_poa += sizeof(*GraphDetails<SizeT>::nodes) * max_nodes_per_window_ * poa_count;                                          // graph_details_h_->nodes
+        host_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;        // graph_details_d_->incoming_edges
+        host_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count; // graph_details_d_->incoming_edge_weights
+        host_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edge_count) * max_nodes_per_window_ * poa_count;                            // graph_details_d_->incoming_edge_count
 
         // for graph - device
-        device_size_per_poa += sizeof(uint8_t) * max_nodes_per_window_ * poa_count;                                                                                           // graph_details_d_->nodes
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * poa_count;                                                               // graph_details_d_->node_alignments
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                                                                                          // graph_details_d_->node_alignment_count
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                    // graph_details_d_->incoming_edges
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                                                                                          // graph_details_d_->incoming_edge_count
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                    // graph_details_d_->outgoing_edges
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                                                                                          // graph_details_d_->outgoing_edge_count
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                 // graph_details_d_->incoming_edge_weights
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                 // graph_details_d_->outgoing_edge_weights
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * poa_count;                                                                                             // graph_details_d_->sorted_poa
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * poa_count;                                                                                             // graph_details_d_->sorted_poa_node_map
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                                                                                          // graph_details_d_->sorted_poa_local_edge_count
-        device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(int32_t) * max_nodes_per_window_ * poa_count : 0;                                              // graph_details_d_->consensus_scores
-        device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(SizeT) * max_nodes_per_window_ * poa_count : 0;                                                // graph_details_d_->consensus_predecessors
-        device_size_per_poa += sizeof(int8_t) * max_nodes_per_window_ * poa_count;                                                                                            // graph_details_d_->node_marks
-        device_size_per_poa += sizeof(bool) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->check_aligned_nodes
-        device_size_per_poa += sizeof(SizeT) * max_nodes_per_window_ * poa_count;                                                                                             // graph_details_d_->nodes_to_visit
-        device_size_per_poa += sizeof(uint16_t) * max_nodes_per_window_ * poa_count;                                                                                          // graph_details_d_->node_coverage_counts
-        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * poa_count : 0; // graph_details_d_->outgoing_edges_coverage
-        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count : 0;                          // graph_details_d_->outgoing_edges_coverage_count
-        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(SizeT) * max_nodes_per_window_ * poa_count : 0;                                                      // graph_details_d_->node_id_to_msa_pos
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::nodes) * max_nodes_per_window_ * poa_count;                                                                                                            // graph_details_d_->nodes
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::node_alignments) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * poa_count;                                                                    // graph_details_d_->node_alignments
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::node_alignment_count) * max_nodes_per_window_ * poa_count;                                                                                             // graph_details_d_->node_alignment_count
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                          // graph_details_d_->incoming_edges
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edge_count) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->incoming_edge_count
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::outgoing_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                          // graph_details_d_->outgoing_edges
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::outgoing_edge_count) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->outgoing_edge_count
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::incoming_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                   // graph_details_d_->incoming_edge_weights
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::outgoing_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                   // graph_details_d_->outgoing_edge_weights
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa) * max_nodes_per_window_ * poa_count;                                                                                                       // graph_details_d_->sorted_poa
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa_node_map) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->sorted_poa_node_map
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa_local_edge_count) * max_nodes_per_window_ * poa_count;                                                                                      // graph_details_d_->sorted_poa_local_edge_count
+        device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(*GraphDetails<SizeT>::consensus_scores) * max_nodes_per_window_ * poa_count : 0;                                                    // graph_details_d_->consensus_scores
+        device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(*GraphDetails<SizeT>::consensus_predecessors) * max_nodes_per_window_ * poa_count : 0;                                              // graph_details_d_->consensus_predecessors
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::node_marks) * max_nodes_per_window_ * poa_count;                                                                                                       // graph_details_d_->node_marks
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::check_aligned_nodes) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->check_aligned_nodes
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::nodes_to_visit) * max_nodes_per_window_ * poa_count;                                                                                                   // graph_details_d_->nodes_to_visit
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::node_coverage_counts) * max_nodes_per_window_ * poa_count;                                                                                             // graph_details_d_->node_coverage_counts
+        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(*GraphDetails<SizeT>::outgoing_edges_coverage) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * poa_count : 0; // graph_details_d_->outgoing_edges_coverage
+        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(*GraphDetails<SizeT>::outgoing_edge_count) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count : 0;                              // graph_details_d_->outgoing_edges_coverage_count
+        device_size_per_poa += (output_mask_ & OutputType::msa) ? sizeof(*GraphDetails<SizeT>::node_id_to_msa_pos) * max_nodes_per_window_ * poa_count : 0;                                                        // graph_details_d_->node_id_to_msa_pos
 
         // for alignment - host
         host_size_fixed += sizeof(AlignmentDetails<ScoreT, SizeT>); // alignment_details_d_
         // for alignment - device
-        device_size_per_poa += sizeof(SizeT) * max_graph_dimension_ * poa_count; // alignment_details_d_->alignment_graph
-        device_size_per_poa += sizeof(SizeT) * max_graph_dimension_ * poa_count; // alignment_details_d_->alignment_read
+        device_size_per_poa += sizeof(*AlignmentDetails<ScoreT, SizeT>::alignment_graph) * max_graph_dimension_ * poa_count; // alignment_details_d_->alignment_graph
+        device_size_per_poa += sizeof(*AlignmentDetails<ScoreT, SizeT>::alignment_read) * max_graph_dimension_ * poa_count;  // alignment_details_d_->alignment_read
 
         return std::make_tuple(host_size_fixed, device_size_fixed, host_size_per_poa, device_size_per_poa);
     }

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -94,7 +94,7 @@ public:
         CGA_CU_CHECK_ERR(cudaFreeHost(block_data_h_));
     }
 
-    void get_output_details(OutputDetails** output_details_h_p, OutputDetails** output_details_d_p)
+        void get_output_details(OutputDetails** output_details_h_p, OutputDetails** output_details_d_p)
     {
         OutputDetails* output_details_h{};
         OutputDetails* output_details_d{};
@@ -103,16 +103,16 @@ public:
         output_details_h = reinterpret_cast<OutputDetails*>(&block_data_h_[offset_h_]);
         offset_h_ += sizeof(OutputDetails);
         output_details_h->consensus = &block_data_h_[offset_h_];
-        offset_h_ += output_size_ * sizeof(uint8_t);
+        offset_h_ += output_size_ * sizeof(*output_details_h->consensus);
         if (output_mask_ & OutputType::consensus)
         {
-            output_details_h->coverage = reinterpret_cast<uint16_t*>(&block_data_h_[offset_h_]);
-            offset_h_ += output_size_ * sizeof(uint16_t);
+            output_details_h->coverage = reinterpret_cast<decltype(output_details_h->coverage)>(&block_data_h_[offset_h_]);
+            offset_h_ += output_size_ * sizeof(*output_details_h->coverage);
         }
         if (output_mask_ & OutputType::msa)
         {
-            output_details_h->multiple_sequence_alignments = reinterpret_cast<uint8_t*>(&block_data_h_[offset_h_]);
-            offset_h_ += output_size_ * max_sequences_per_poa_ * sizeof(uint8_t);
+            output_details_h->multiple_sequence_alignments = reinterpret_cast<decltype(output_details_h->multiple_sequence_alignments)>(&block_data_h_[offset_h_]);
+            offset_h_ += output_size_ * max_sequences_per_poa_ * sizeof(*output_details_h->multiple_sequence_alignments);
         }
 
         output_details_d = reinterpret_cast<OutputDetails*>(&block_data_h_[offset_h_]);
@@ -120,16 +120,16 @@ public:
 
         // on device
         output_details_d->consensus = &block_data_d_[offset_d_];
-        offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(int8_t));
+        offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(*output_details_d->consensus));
         if (output_mask_ & OutputType::consensus)
         {
-            output_details_d->coverage = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(int16_t));
+            output_details_d->coverage = reinterpret_cast<decltype(output_details_d->coverage)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(*output_details_d->coverage));
         }
         if (output_mask_ & OutputType::msa)
         {
-            output_details_d->multiple_sequence_alignments = reinterpret_cast<uint8_t*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(output_size_ * max_sequences_per_poa_ * sizeof(uint8_t));
+            output_details_d->multiple_sequence_alignments = reinterpret_cast<decltype(output_details_d->multiple_sequence_alignments)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(output_size_ * max_sequences_per_poa_ * sizeof(*output_details_d->multiple_sequence_alignments));
         }
 
         *output_details_h_p = output_details_h;
@@ -145,17 +145,17 @@ public:
         input_details_h = reinterpret_cast<InputDetails<SizeT>*>(&block_data_h_[offset_h_]);
         offset_h_ += sizeof(InputDetails<SizeT>);
         input_details_h->sequences = &block_data_h_[offset_h_];
-        offset_h_ += input_size_ * sizeof(uint8_t);
-        input_details_h->base_weights = reinterpret_cast<int8_t*>(&block_data_h_[offset_h_]);
-        offset_h_ += input_size_ * sizeof(int8_t);
-        input_details_h->sequence_lengths = reinterpret_cast<SizeT*>(&block_data_h_[offset_h_]);
-        offset_h_ += max_poas_ * max_sequences_per_poa_ * sizeof(SizeT);
-        input_details_h->window_details = reinterpret_cast<WindowDetails*>(&block_data_h_[offset_h_]);
-        offset_h_ += max_poas_ * sizeof(WindowDetails);
+        offset_h_ += input_size_ * sizeof(*input_details_h->sequences);
+        input_details_h->base_weights = reinterpret_cast<decltype(input_details_h->base_weights)>(&block_data_h_[offset_h_]);
+        offset_h_ += input_size_ * sizeof(*input_details_h->base_weights);
+        input_details_h->sequence_lengths = reinterpret_cast<decltype(input_details_h->sequence_lengths)>(&block_data_h_[offset_h_]);
+        offset_h_ += max_poas_ * max_sequences_per_poa_ * sizeof(*input_details_h->sequence_lengths);
+        input_details_h->window_details = reinterpret_cast<decltype(input_details_h->window_details)>(&block_data_h_[offset_h_]);
+        offset_h_ += max_poas_ * sizeof(*input_details_h->window_details);
         if (output_mask_ & OutputType::msa)
         {
-            input_details_h->sequence_begin_nodes_ids = reinterpret_cast<SizeT*>(&block_data_h_[offset_h_]);
-            offset_h_ += max_poas_ * max_sequences_per_poa_ * sizeof(SizeT);
+            input_details_h->sequence_begin_nodes_ids = reinterpret_cast<decltype(input_details_h->sequence_begin_nodes_ids)>(&block_data_h_[offset_h_]);
+            offset_h_ += max_poas_ * max_sequences_per_poa_ * sizeof(*input_details_h->sequence_begin_nodes_ids);
         }
 
         input_details_d = reinterpret_cast<InputDetails<SizeT>*>(&block_data_h_[offset_h_]);
@@ -163,24 +163,24 @@ public:
 
         // on device
         input_details_d->sequences = &block_data_d_[offset_d_];
-        offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(uint8_t));
-        input_details_d->base_weights = reinterpret_cast<int8_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(int8_t));
-        input_details_d->sequence_lengths = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(SizeT));
-        input_details_d->window_details = reinterpret_cast<WindowDetails*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * sizeof(WindowDetails));
+        offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(*input_details_d->sequences));
+        input_details_d->base_weights = reinterpret_cast<decltype(input_details_d->base_weights)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(*input_details_d->base_weights));
+        input_details_d->sequence_lengths = reinterpret_cast<decltype(input_details_d->sequence_lengths)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(*input_details_d->sequence_lengths));
+        input_details_d->window_details = reinterpret_cast<decltype(input_details_d->window_details)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * sizeof(*input_details_d->window_details));
         if (output_mask_ & OutputType::msa)
         {
-            input_details_d->sequence_begin_nodes_ids = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(SizeT));
+            input_details_d->sequence_begin_nodes_ids = reinterpret_cast<decltype(input_details_d->sequence_begin_nodes_ids)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(*input_details_d->sequence_begin_nodes_ids));
         }
 
         *input_details_h_p = input_details_h;
         *input_details_d_p = input_details_d;
     }
 
-    void get_alignment_details(AlignmentDetails<ScoreT, SizeT>** alignment_details_d_p)
+        void get_alignment_details(AlignmentDetails<ScoreT, SizeT>** alignment_details_d_p)
     {
         AlignmentDetails<ScoreT, SizeT>* alignment_details_d{};
 
@@ -189,14 +189,14 @@ public:
         offset_h_ += sizeof(AlignmentDetails<ScoreT, SizeT>);
 
         // on device;
-        alignment_details_d->alignment_graph = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_graph_dimension_ * max_poas_);
-        alignment_details_d->alignment_read = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_graph_dimension_ * max_poas_);
+        alignment_details_d->alignment_graph = reinterpret_cast<decltype(alignment_details_d->alignment_graph)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*alignment_details_d->alignment_graph) * max_graph_dimension_ * max_poas_);
+        alignment_details_d->alignment_read = reinterpret_cast<decltype(alignment_details_d->alignment_read)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*alignment_details_d->alignment_read) * max_graph_dimension_ * max_poas_);
 
         // rest of the available memory is assigned to scores buffer
         alignment_details_d->scorebuf_alloc_size = total_d_ - offset_d_;
-        alignment_details_d->scores              = reinterpret_cast<ScoreT*>(&block_data_d_[offset_d_]);
+        alignment_details_d->scores              = reinterpret_cast<decltype(alignment_details_d->scores)>(&block_data_d_[offset_d_]);
         *alignment_details_d_p                   = alignment_details_d;
     }
 
@@ -209,66 +209,66 @@ public:
         graph_details_h = reinterpret_cast<GraphDetails<SizeT>*>(&block_data_h_[offset_h_]);
         offset_h_ += sizeof(GraphDetails<SizeT>);
         graph_details_h->nodes = &block_data_h_[offset_h_];
-        offset_h_ += sizeof(uint8_t) * max_nodes_per_window_ * max_poas_;
-        graph_details_h->incoming_edges = reinterpret_cast<SizeT*>(&block_data_h_[offset_h_]);
-        offset_h_ += sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_;
-        graph_details_h->incoming_edge_weights = reinterpret_cast<uint16_t*>(&block_data_h_[offset_h_]);
-        offset_h_ += sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_;
-        graph_details_h->incoming_edge_count = reinterpret_cast<uint16_t*>(&block_data_h_[offset_h_]);
-        offset_h_ += sizeof(uint16_t) * max_nodes_per_window_ * max_poas_;
+        offset_h_ += sizeof(*graph_details_h->nodes) * max_nodes_per_window_ * max_poas_;
+        graph_details_h->incoming_edges = reinterpret_cast<decltype(graph_details_h->incoming_edges)>(&block_data_h_[offset_h_]);
+        offset_h_ += sizeof(*graph_details_h->incoming_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_;
+        graph_details_h->incoming_edge_weights = reinterpret_cast<decltype(graph_details_h->incoming_edge_weights)>(&block_data_h_[offset_h_]);
+        offset_h_ += sizeof(*graph_details_h->incoming_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_;
+        graph_details_h->incoming_edge_count = reinterpret_cast<decltype(graph_details_h->incoming_edge_count)>(&block_data_h_[offset_h_]);
+        offset_h_ += sizeof(*graph_details_h->incoming_edge_count) * max_nodes_per_window_ * max_poas_;
         graph_details_d = reinterpret_cast<GraphDetails<SizeT>*>(&block_data_h_[offset_h_]);
         offset_h_ += sizeof(GraphDetails<SizeT>);
         graph_details_d->nodes = &block_data_h_[offset_h_];
 
         // on device
         graph_details_d->nodes = &block_data_d_[offset_d_];
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint8_t) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->node_alignments = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * max_poas_);
-        graph_details_d->node_alignment_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->incoming_edges = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
-        graph_details_d->incoming_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->outgoing_edges = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
-        graph_details_d->outgoing_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->incoming_edge_weights = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
-        graph_details_d->outgoing_edge_weights = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
-        graph_details_d->sorted_poa = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->sorted_poa_node_map = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->sorted_poa_local_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_h->nodes) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->node_alignments = reinterpret_cast<decltype(graph_details_d->node_alignments)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_alignments) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * max_poas_);
+        graph_details_d->node_alignment_count = reinterpret_cast<decltype(graph_details_d->node_alignment_count)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_alignment_count) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->incoming_edges = reinterpret_cast<decltype(graph_details_d->incoming_edges)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->incoming_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+        graph_details_d->incoming_edge_count = reinterpret_cast<decltype(graph_details_d->incoming_edge_count)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->incoming_edge_count) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->outgoing_edges = reinterpret_cast<decltype(graph_details_d->outgoing_edges)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->outgoing_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+        graph_details_d->outgoing_edge_count = reinterpret_cast<decltype(graph_details_d->outgoing_edge_count)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->outgoing_edge_count) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->incoming_edge_weights = reinterpret_cast<decltype(graph_details_d->incoming_edge_weights)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->incoming_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+        graph_details_d->outgoing_edge_weights = reinterpret_cast<decltype(graph_details_d->outgoing_edge_weights)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->outgoing_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+        graph_details_d->sorted_poa = reinterpret_cast<decltype(graph_details_d->sorted_poa)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->sorted_poa_node_map = reinterpret_cast<decltype(graph_details_d->sorted_poa_node_map)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa_node_map) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->sorted_poa_local_edge_count = reinterpret_cast<decltype(graph_details_d->sorted_poa_local_edge_count)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa_local_edge_count) * max_nodes_per_window_ * max_poas_);
         if (output_mask_ & OutputType::consensus)
         {
-            graph_details_d->consensus_scores = reinterpret_cast<int32_t*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(sizeof(int32_t) * max_nodes_per_window_ * max_poas_);
-            graph_details_d->consensus_predecessors = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * max_poas_);
+            graph_details_d->consensus_scores = reinterpret_cast<decltype(graph_details_d->consensus_scores)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->consensus_scores) * max_nodes_per_window_ * max_poas_);
+            graph_details_d->consensus_predecessors = reinterpret_cast<decltype(graph_details_d->consensus_predecessors)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->consensus_predecessors) * max_nodes_per_window_ * max_poas_);
         }
 
-        graph_details_d->node_marks = reinterpret_cast<uint8_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(int8_t) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->check_aligned_nodes = reinterpret_cast<bool*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(bool) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->nodes_to_visit = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * max_poas_);
-        graph_details_d->node_coverage_counts = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->node_marks = reinterpret_cast<decltype(graph_details_d->node_marks)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_marks) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->check_aligned_nodes = reinterpret_cast<decltype(graph_details_d->check_aligned_nodes)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->check_aligned_nodes) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->nodes_to_visit = reinterpret_cast<decltype(graph_details_d->nodes_to_visit)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->nodes_to_visit) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->node_coverage_counts = reinterpret_cast<decltype(graph_details_d->node_coverage_counts)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_coverage_counts) * max_nodes_per_window_ * max_poas_);
         if (output_mask_ & OutputType::msa)
         {
-            graph_details_d->outgoing_edges_coverage = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * max_poas_);
-            graph_details_d->outgoing_edges_coverage_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
-            graph_details_d->node_id_to_msa_pos = reinterpret_cast<SizeT*>(&block_data_d_[offset_d_]);
-            offset_d_ += cudautils::align<int64_t, 8>(sizeof(SizeT) * max_nodes_per_window_ * max_poas_);
+            graph_details_d->outgoing_edges_coverage = reinterpret_cast<decltype(graph_details_d->outgoing_edges_coverage)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->outgoing_edges_coverage) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * max_poas_);
+            graph_details_d->outgoing_edges_coverage_count = reinterpret_cast<decltype(graph_details_d->outgoing_edges_coverage_count)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->outgoing_edges_coverage_count) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+            graph_details_d->node_id_to_msa_pos = reinterpret_cast<decltype(graph_details_d->node_id_to_msa_pos)>(&block_data_d_[offset_d_]);
+            offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_id_to_msa_pos) * max_nodes_per_window_ * max_poas_);
         }
 
         *graph_details_d_p = graph_details_d;

--- a/cudapoa/src/cudapoa_batch.hpp
+++ b/cudapoa/src/cudapoa_batch.hpp
@@ -207,12 +207,12 @@ public:
         print_batch_debug_message(msg);
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_concensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->coverage,
                                          output_details_d_->coverage,
-                                         batch_size_.max_concensus_size * max_poas_ * sizeof(uint16_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint16_t),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
         CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream_));
@@ -224,7 +224,7 @@ public:
         {
             // Get the consensus string and reverse it since on GPU the
             // string is built backwards..
-            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_concensus_size]));
+            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_consensus_size]));
             // We use the first two entries in the consensus buffer to log error during kernel execution
             // c[0] == 0 means an error occured and when that happens the error type is saved in c[1]
             if (static_cast<uint8_t>(c[0]) == CUDAPOA_KERNEL_ERROR_ENCOUNTERED)
@@ -241,8 +241,8 @@ public:
                 std::reverse(consensus.back().begin(), consensus.back().end());
                 // Similarly, get the coverage and reverse it.
                 coverage.emplace_back(std::vector<uint16_t>(
-                    &(output_details_h_->coverage[poa * batch_size_.max_concensus_size]),
-                    &(output_details_h_->coverage[poa * batch_size_.max_concensus_size + get_size(consensus.back())])));
+                    &(output_details_h_->coverage[poa * batch_size_.max_consensus_size]),
+                    &(output_details_h_->coverage[poa * batch_size_.max_consensus_size + get_size(consensus.back())])));
                 std::reverse(coverage.back().begin(), coverage.back().end());
                 //std::cout << consensus.back() << std::endl;
             }
@@ -266,13 +266,13 @@ public:
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->multiple_sequence_alignments,
                                          output_details_d_->multiple_sequence_alignments,
-                                         max_poas_ * max_sequences_per_poa_ * batch_size_.max_concensus_size * sizeof(uint8_t),
+                                         max_poas_ * max_sequences_per_poa_ * batch_size_.max_consensus_size * sizeof(uint8_t),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_concensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
@@ -284,7 +284,7 @@ public:
         for (int32_t poa = 0; poa < poa_count_; poa++)
         {
             msa.emplace_back(std::vector<std::string>());
-            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_concensus_size]));
+            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_consensus_size]));
             // We use the first two entries in the consensus buffer to log error during kernel execution
             // c[0] == 0 means an error occured and when that happens the error type is saved in c[1]
             if (static_cast<uint8_t>(c[0]) == CUDAPOA_KERNEL_ERROR_ENCOUNTERED)
@@ -297,7 +297,7 @@ public:
                 uint16_t num_seqs = input_details_h_->window_details[poa].num_seqs;
                 for (uint16_t i = 0; i < num_seqs; i++)
                 {
-                    char* c = reinterpret_cast<char*>(&(output_details_h_->multiple_sequence_alignments[(poa * max_sequences_per_poa_ + i) * batch_size_.max_concensus_size]));
+                    char* c = reinterpret_cast<char*>(&(output_details_h_->multiple_sequence_alignments[(poa * max_sequences_per_poa_ + i) * batch_size_.max_consensus_size]));
                     msa[poa].emplace_back(std::string(c));
                 }
             }
@@ -342,7 +342,7 @@ public:
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_concensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
@@ -353,7 +353,7 @@ public:
 
         for (int32_t poa = 0; poa < poa_count_; poa++)
         {
-            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_concensus_size]));
+            char* c = reinterpret_cast<char*>(&(output_details_h_->consensus[poa * batch_size_.max_consensus_size]));
             // We use the first two entries in the consensus buffer to log error during kernel execution
             // c[0] == 0 means an error occured and when that happens the error type is saved in c[1]
             if (static_cast<uint8_t>(c[0]) == CUDAPOA_KERNEL_ERROR_ENCOUNTERED)

--- a/cudapoa/src/cudapoa_batch.hpp
+++ b/cudapoa/src/cudapoa_batch.hpp
@@ -161,11 +161,11 @@ public:
 
         //Copy sequencecs, sequence lengths and window details to device
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->sequences, input_details_h_->sequences,
-                                         num_nucleotides_copied_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream_));
+                                         num_nucleotides_copied_ * sizeof(*input_details_h_->sequences), cudaMemcpyHostToDevice, stream_));
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->base_weights, input_details_h_->base_weights,
-                                         num_nucleotides_copied_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream_));
+                                         num_nucleotides_copied_ * sizeof(*input_details_h_->base_weights), cudaMemcpyHostToDevice, stream_));
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->window_details, input_details_h_->window_details,
-                                         poa_count_ * sizeof(genomeworks::cudapoa::WindowDetails), cudaMemcpyHostToDevice, stream_));
+                                         poa_count_ * sizeof(*input_details_h->window_details), cudaMemcpyHostToDevice, stream_));
         /// ToDo may need to revise the following sizeof()
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->sequence_lengths, input_details_h_->sequence_lengths,
                                          global_sequence_idx_ * sizeof(*input_details_h_->sequence_lengths), cudaMemcpyHostToDevice, stream_));
@@ -207,12 +207,12 @@ public:
         print_batch_debug_message(msg);
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(*output_details_h_->consensus),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->coverage,
                                          output_details_d_->coverage,
-                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint16_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(*output_details_h_->coverage),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
         CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream_));
@@ -266,13 +266,13 @@ public:
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->multiple_sequence_alignments,
                                          output_details_d_->multiple_sequence_alignments,
-                                         max_poas_ * max_sequences_per_poa_ * batch_size_.max_consensus_size * sizeof(uint8_t),
+                                         max_poas_ * max_sequences_per_poa_ * batch_size_.max_consensus_size * sizeof(*output_details_h_->multiple_sequence_alignments),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(*output_details_h_->consensus),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
@@ -312,37 +312,37 @@ public:
         int32_t max_nodes_per_window_ = banded_alignment_ ? batch_size_.max_nodes_per_window_banded : batch_size_.max_nodes_per_window;
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(graph_details_h_->nodes,
                                          graph_details_d_->nodes,
-                                         sizeof(uint8_t) * max_nodes_per_window_ * max_poas_,
+                                         sizeof(*graph_details_h_->nodes) * max_nodes_per_window_ * max_poas_,
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(graph_details_h_->incoming_edges,
                                          graph_details_d_->incoming_edges,
-                                         sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_,
+                                         sizeof(*graph_details_h_->incoming_edges) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_,
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(graph_details_h_->incoming_edge_weights,
                                          graph_details_d_->incoming_edge_weights,
-                                         sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_,
+                                         sizeof(*graph_details_h_->incoming_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_,
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(graph_details_h_->incoming_edge_count,
                                          graph_details_d_->incoming_edge_count,
-                                         sizeof(uint16_t) * max_nodes_per_window_ * max_poas_,
+                                         sizeof(*graph_details_h_->incoming_edge_count) * max_nodes_per_window_ * max_poas_,
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_h_->sequence_lengths,
                                          input_details_d_->sequence_lengths,
-                                         global_sequence_idx_ * sizeof(uint16_t),
+                                         global_sequence_idx_ * sizeof(*input_details_h_->sequence_lengths),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(output_details_h_->consensus,
                                          output_details_d_->consensus,
-                                         batch_size_.max_consensus_size * max_poas_ * sizeof(uint8_t),
+                                         batch_size_.max_consensus_size * max_poas_ * sizeof(*output_details_h_->consensus),
                                          cudaMemcpyDeviceToHost,
                                          stream_));
 

--- a/cudapoa/src/cudapoa_batch.hpp
+++ b/cudapoa/src/cudapoa_batch.hpp
@@ -165,7 +165,7 @@ public:
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->base_weights, input_details_h_->base_weights,
                                          num_nucleotides_copied_ * sizeof(*input_details_h_->base_weights), cudaMemcpyHostToDevice, stream_));
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->window_details, input_details_h_->window_details,
-                                         poa_count_ * sizeof(*input_details_h->window_details), cudaMemcpyHostToDevice, stream_));
+                                         poa_count_ * sizeof(*input_details_h_->window_details), cudaMemcpyHostToDevice, stream_));
         /// ToDo may need to revise the following sizeof()
         CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->sequence_lengths, input_details_h_->sequence_lengths,
                                          global_sequence_idx_ * sizeof(*input_details_h_->sequence_lengths), cudaMemcpyHostToDevice, stream_));

--- a/cudapoa/src/cudapoa_kernels.cu
+++ b/cudapoa/src/cudapoa_kernels.cu
@@ -458,7 +458,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                  outgoing_edges_coverage_count,
                                                                                  batch_size.max_nodes_per_window_banded,
                                                                                  batch_size.max_matrix_graph_dimension_banded,
-                                                                                 batch_size.max_concensus_size,
+                                                                                 batch_size.max_consensus_size,
                                                                                  batch_size.alignment_band_width);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
 
@@ -482,7 +482,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                        consensus_predecessors,
                                                                                        node_coverage_counts,
                                                                                        batch_size.max_nodes_per_window_banded,
-                                                                                       batch_size.max_concensus_size);
+                                                                                       batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
         }
         if (output_mask & OutputType::msa)
@@ -522,7 +522,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                  outgoing_edges_coverage_count,
                                                                                  batch_size.max_nodes_per_window_banded,
                                                                                  batch_size.max_matrix_graph_dimension_banded,
-                                                                                 batch_size.max_concensus_size,
+                                                                                 batch_size.max_consensus_size,
                                                                                  batch_size.alignment_band_width);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
 
@@ -550,7 +550,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                       nodes_to_visit,
                                                                       batch_size.max_nodes_per_window,
                                                                       batch_size.max_nodes_per_window_banded,
-                                                                      batch_size.max_concensus_size);
+                                                                      batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
         }
     }
@@ -593,7 +593,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                     outgoing_edges_coverage_count,
                                                                     batch_size.max_nodes_per_window,
                                                                     batch_size.max_matrix_graph_dimension,
-                                                                    batch_size.max_concensus_size);
+                                                                    batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
 
             generateConsensusKernel<false, SizeT>
@@ -616,7 +616,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                        consensus_predecessors,
                                                                                        node_coverage_counts,
                                                                                        batch_size.max_nodes_per_window,
-                                                                                       batch_size.max_concensus_size);
+                                                                                       batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
         }
         if (output_mask & OutputType::msa)
@@ -656,7 +656,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                     outgoing_edges_coverage_count,
                                                                     batch_size.max_nodes_per_window,
                                                                     batch_size.max_matrix_graph_dimension,
-                                                                    batch_size.max_concensus_size);
+                                                                    batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
 
             generateMSAKernel<false, SizeT>
@@ -683,7 +683,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                       nodes_to_visit,
                                                                       batch_size.max_nodes_per_window,
                                                                       batch_size.max_nodes_per_window_banded,
-                                                                      batch_size.max_concensus_size);
+                                                                      batch_size.max_consensus_size);
             CGA_CU_CHECK_ERR(cudaPeekAtLastError());
         }
     }
@@ -1068,7 +1068,7 @@ bool use32bitScore(const BatchSize& batch_size, const int16_t gap_score, const i
 
 bool use32bitSize(const BatchSize& batch_size, bool banded)
 {
-    int32_t max_length = batch_size.max_concensus_size;
+    int32_t max_length = batch_size.max_consensus_size;
     if (banded)
     {
         max_length = std::max(max_length, batch_size.max_matrix_graph_dimension_banded);

--- a/cudapoa/tests/Test_CudapoaGenerateConsensus.cpp
+++ b/cudapoa/tests/Test_CudapoaGenerateConsensus.cpp
@@ -200,8 +200,8 @@ std::string testGenerateConsensus(const BasicGenerateConsensus& obj)
 
     CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&predecessors, batch_size.max_nodes_per_window * sizeof(SizeT)));
     CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&scores, batch_size.max_nodes_per_window * sizeof(int32_t)));
-    CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&consensus, batch_size.max_concensus_size * sizeof(uint8_t)));
-    CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&coverage, batch_size.max_concensus_size * sizeof(uint16_t)));
+    CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&consensus, batch_size.max_consensus_size * sizeof(uint8_t)));
+    CGA_CU_CHECK_ERR(cudaMallocManaged((void**)&coverage, batch_size.max_consensus_size * sizeof(uint16_t)));
 
     //initialize all 'count' buffers
     memset((void**)incoming_edge_count, 0, batch_size.max_nodes_per_window * sizeof(uint16_t));
@@ -234,7 +234,7 @@ std::string testGenerateConsensus(const BasicGenerateConsensus& obj)
                               node_coverage_counts,
                               node_alignments,
                               node_alignment_count,
-                              batch_size.max_concensus_size,
+                              batch_size.max_consensus_size,
                               false, batch_size);
 
     CGA_CU_CHECK_ERR(cudaDeviceSynchronize());

--- a/cudapoa/tests/Test_CudapoaGenerateMSA2.cpp
+++ b/cudapoa/tests/Test_CudapoaGenerateMSA2.cpp
@@ -129,9 +129,9 @@ TEST_F(MSATest, CudapoaMSAFailure)
     std::minstd_rand rng(1);
     int num_sequences = 10;
     BatchSize batch_size(1024, num_sequences);
-    batch_size.max_concensus_size = batch_size.max_sequence_size;
+    batch_size.max_consensus_size = batch_size.max_sequence_size;
 
-    std::string backbone = genomeworks::genomeutils::generate_random_genome(batch_size.max_concensus_size - 1, rng);
+    std::string backbone = genomeworks::genomeutils::generate_random_genome(batch_size.max_consensus_size - 1, rng);
     auto sequences       = genomeworks::genomeutils::generate_random_sequences(backbone, num_sequences, rng, 10, 5, 10);
 
     initialize(batch_size);

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pxd
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pxd
@@ -60,7 +60,7 @@ cdef extern from "claragenomics/cudapoa/batch.hpp" namespace "claraparabricks::g
 
     cdef cppclass BatchSize:
         int32_t max_sequence_size
-        int32_t max_concensus_size
+        int32_t max_consensus_size
         int32_t max_nodes_per_window
         int32_t max_nodes_per_window_banded
         int32_t max_matrix_graph_dimension

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -74,7 +74,7 @@ cdef class CudaPoaBatch:
             match_score=8,
             cuda_banded_alignment=False,
             alignment_band_width=128,
-            max_concensus_size=None,
+            max_consensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,
             *args,
@@ -94,7 +94,7 @@ cdef class CudaPoaBatch:
             match_score : Reward for match
             cuda_banded_alignment : Run POA using banded alignment
             alignment_band_width : Band-width size if using banded alignment
-            max_concensus_size : Maximum size of final consensus
+            max_consensus_size : Maximum size of final consensus
             max_nodes_per_window : Maximum number of nodes in a graph, 1 graph per window
             max_nodes_per_window_banded : Maximum number of nodes in a graph, 1 graph per window in banded mode
         """
@@ -120,15 +120,15 @@ cdef class CudaPoaBatch:
         cdef int32_t mx_seq_sz = max_sequence_size
         cdef int32_t band_width_sz = alignment_band_width
         cdef int32_t mx_seq_per_poa = max_sequences_per_poa
-        cdef int32_t mx_concensus_sz = \
-            2 * max_sequence_size if max_concensus_size is None else max_concensus_size
+        cdef int32_t mx_consensus_sz = \
+            2 * max_sequence_size if max_consensus_size is None else max_consensus_size
         cdef int32_t mx_nodes_per_w = \
             3 * max_sequence_size if max_nodes_per_window is None else max_nodes_per_window
         cdef int32_t mx_nodes_per_w_banded = \
             4 * max_sequence_size if max_nodes_per_window_banded is None else max_nodes_per_window_banded
 
         self.batch_size = make_unique[cudapoa.BatchSize](
-            mx_seq_sz, mx_concensus_sz, mx_nodes_per_w,
+            mx_seq_sz, mx_consensus_sz, mx_nodes_per_w,
             mx_nodes_per_w_banded, band_width_sz, mx_seq_per_poa)
 
         self.batch = cudapoa.create_batch(
@@ -155,7 +155,7 @@ cdef class CudaPoaBatch:
             match_score=8,
             cuda_banded_alignment=False,
             alignment_band_width=128,
-            max_concensus_size=None,
+            max_consensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,
             *args,


### PR DESCRIPTION
- Changed allocation in allocate_block.hpp to infer size and type from data type. 

- Also made similar changes in cudapoa_batch.hpp. 

- Renamed typo concensus to consensus.